### PR TITLE
Fix small typo and add zeal-at-point-search

### DIFF
--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -181,6 +181,14 @@ the combined docset.")
                                'zeal-at-point--docset-history (zeal-at-point-get-docset)))
   )
 
+;;;###autoload
+(defun zeal-at-point-search (&optional edit-search)
+  "Prompt and search in zeal"
+  (interactive "P")
+  (let ((search (zeal-at-point-maybe-add-docset "")))
+    (zeal-at-point-run-search
+     (read-string "Zeal search: " search))))
+
 (provide 'zeal-at-point)
 
 ;;; zeal-at-point.el ends here

--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -128,7 +128,7 @@ which sets this variable to \"allruby\" so that Zeal will search
 the combined docset.")
 (make-variable-buffer-local 'zeal-at-point-docset)
 
-(defvar zeal-at-point--docset-hitory nil)
+(defvar zeal-at-point--docset-history nil)
 
 (unless (fboundp 'setq-local)
   (defmacro setq-local (var val)
@@ -178,7 +178,7 @@ the combined docset.")
   (setq-local zeal-at-point-docset
               (completing-read (zeal-at-point--set-docset-prompt)
                                (zeal-at-point--docset-candidates) nil nil nil
-                               'zeal-at-point--docset-hitory (zeal-at-point-get-docset)))
+                               'zeal-at-point--docset-history (zeal-at-point-get-docset)))
   )
 
 (provide 'zeal-at-point)


### PR DESCRIPTION
I wanted to have a separate "just search" function so I could bind it to a key and not have the mark added to the search (sometimes that's what I want to do), so I added `zeal-at-point-search`.