### PR TITLE
Fix Zeal 0.2.1 incompatibility

### DIFF
--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -130,6 +130,15 @@ the combined docset.")
 
 (defvar zeal-at-point--docset-hitory nil)
 
+(defvar zeal-at-point-zeal-version
+  (when (executable-find "zeal")
+    (let ((output (with-temp-buffer
+                    (call-process "zeal" nil t nil "--version")
+                    (buffer-string))))
+      (when (string-match "Zeal \\([[:digit:]\\.]+\\)" output)
+        (match-string 1 output))))
+  "The version of zeal installed on the system.")
+
 (unless (fboundp 'setq-local)
   (defmacro setq-local (var val)
     `(set (make-local-variable ',var) ,val)))
@@ -147,9 +156,10 @@ the combined docset.")
 
 (defun zeal-at-point-run-search (search)
   (if (executable-find "zeal")
-      (start-process "Zeal" nil "zeal" "--query" search)
-    (message "Zeal wasn't found, install it first http://zealdocs.org"))
-  )
+      (if (version< "0.2.0" zeal-at-point-zeal-version)
+          (start-process "Zeal" nil "zeal" search)
+        (start-process "Zeal" nil "zeal" "--query" search))
+    (message "Zeal wasn't found, install it first http://zealdocs.org")))
 
 ;;;###autoload
 (defun zeal-at-point (&optional edit-search)


### PR DESCRIPTION
Support for `--query` was dropped a week ago: https://github.com/zealdocs/zeal/commit/4e8717f8ebc98cc81f359529b0ef0153eff3edc6

This PR adds a variable `zeal-at-point-zeal-version` that can be used to decide between the two forms.