### PR TITLE
Don't use alias

### DIFF
--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -68,7 +68,7 @@
     (c-mode . "c")
     (clojure-mode . "clojure")
     (coffee-mode . "coffee")
-    (common-lisp-mode . "lisp")
+    (lisp-mode . "lisp")
     (cperl-mode . "perl")
     (css-mode . "css")
     (elixir-mode . "elixir")


### PR DESCRIPTION
common-lisp-mode is an alias of lisp-mode.

This is related to #18.
CC: @darkfeline