### PR TITLE
add custom variable zeal-at-point-exe 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.elc
+*~
+*loaddefs.el
+*autoloads.el

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+emacs ?= emacs
+wget ?= wget
+
+elpa_dir ?= ~/.emacs.d/elpa
+auto ?= zeal-at-point-autoloads.el
+
+el = $(filter-out $(auto) .dir-locals.el,$(wildcard *.el))
+elc = $(el:.el=.elc)
+
+batch_flags = -batch \
+	--eval "(let ((default-directory                   \
+                      (expand-file-name \"$(elpa_dir)\"))) \
+                  (normal-top-level-add-subdirs-to-load-path))"
+
+auto_flags ?= \
+	--eval "(let ((generated-autoload-file                       \
+                      (expand-file-name (unmsys--file-name \"$@\"))) \
+                      (wd (expand-file-name default-directory))      \
+                      (backup-inhibited t)                           \
+                      (default-directory                             \
+	                (expand-file-name \"$(elpa_dir)\")))         \
+                   (normal-top-level-add-subdirs-to-load-path)       \
+                   (update-directory-autoloads wd))"
+
+.PHONY: $(auto) clean distclean
+all: compile $(auto)
+
+compile : $(elc)
+%.elc : %.el
+	$(emacs) $(batch_flags) -f batch-byte-compile $<
+
+$(auto):
+	$(emacs) -batch $(auto_flags)
+
+TAGS: $(el)
+	$(RM) $@
+	touch $@
+	ls $(el) | xargs etags -a -o $@
+
+clean:
+	$(RM) *~
+
+distclean: clean
+	$(RM) *autoloads.el *loaddefs.el TAGS *.elc

--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -59,7 +59,14 @@
 
 (defgroup zeal-at-point nil
   "Searching in Zeal for text at point"
-  :group 'external)
+  :group 'external
+  :prefix "zeal-at-point-")
+
+(defcustom zeal-at-point-exe
+  (executable-find "zeal")
+  "Location of zeal executable."
+  :group 'zeal-at-point
+  :type 'string)
 
 (defcustom zeal-at-point-mode-alist
   '((actionscript-mode . "actionscript")
@@ -131,9 +138,9 @@ the combined docset.")
 (defvar zeal-at-point--docset-history nil)
 
 (defvar zeal-at-point-zeal-version
-  (when (executable-find "zeal")
+  (when zeal-at-point-exe
     (let ((output (with-temp-buffer
-                    (call-process "zeal" nil t nil "--version")
+                    (call-process zeal-at-point-exe nil t nil "--version")
                     (buffer-string))))
       (when (string-match "Zeal \\([[:digit:]\\.]+\\)" output)
         (match-string 1 output))))
@@ -155,10 +162,10 @@ the combined docset.")
             search-string)))
 
 (defun zeal-at-point-run-search (search)
-  (if (executable-find "zeal")
+  (if zeal-at-point-exe
       (if (version< "0.2.0" zeal-at-point-zeal-version)
-          (start-process "Zeal" nil "zeal" search)
-        (start-process "Zeal" nil "zeal" "--query" search))
+          (start-process "Zeal" nil zeal-at-point-exe search)
+        (start-process "Zeal" nil zeal-at-point-exe "--query" search))
     (message "Zeal wasn't found, install it first http://zealdocs.org")))
 
 ;;;###autoload

--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -153,7 +153,8 @@ the combined docset.")
                (buffer-string))))
         (when (string-match "Zeal \\([[:digit:]\\.]+\\)" output)
           (setq zeal-at-point-zeal-version
-                (match-string 1 output))))))
+                (match-string 1 output)))
+        zeal-at-point-zeal-version)))
 
 (defun zeal-at-point-get-docset ()
   "Guess which docset suit to the current major mode."

--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -137,18 +137,23 @@ the combined docset.")
 
 (defvar zeal-at-point--docset-history nil)
 
-(defvar zeal-at-point-zeal-version
-  (when zeal-at-point-exe
-    (let ((output (with-temp-buffer
-                    (call-process zeal-at-point-exe nil t nil "--version")
-                    (buffer-string))))
-      (when (string-match "Zeal \\([[:digit:]\\.]+\\)" output)
-        (match-string 1 output))))
-  "The version of zeal installed on the system.")
-
 (unless (fboundp 'setq-local)
   (defmacro setq-local (var val)
     `(set (make-local-variable ',var) ,val)))
+
+(defvar zeal-at-point-zeal-version nil
+  "The version of zeal installed on the system.")
+
+(defun zeal-at-point-get-version ()
+  "Find installed zeal version."
+  (or zeal-at-point-zeal-version
+      (let ((output
+             (with-temp-buffer
+               (call-process zeal-at-point-exe nil t nil "--version")
+               (buffer-string))))
+        (when (string-match "Zeal \\([[:digit:]\\.]+\\)" output)
+          (setq zeal-at-point-zeal-version
+                (match-string 1 output))))))
 
 (defun zeal-at-point-get-docset ()
   "Guess which docset suit to the current major mode."
@@ -163,7 +168,7 @@ the combined docset.")
 
 (defun zeal-at-point-run-search (search)
   (if zeal-at-point-exe
-      (if (version< "0.2.0" zeal-at-point-zeal-version)
+      (if (version< "0.2.0" (zeal-at-point-get-version))
           (start-process "Zeal" nil zeal-at-point-exe search)
         (start-process "Zeal" nil zeal-at-point-exe "--query" search))
     (message "Zeal wasn't found, install it first http://zealdocs.org")))


### PR DESCRIPTION
If you're interested, added variable zeal-at-point-exe so zeal isn't assumed to be on exec-path.  Everything else should be the same, although since the version is created at compile I added a function to define the version if it is nil.