### PR TITLE
Docset for c++ is 'cpp', not 'c++'

### DIFF
--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -73,7 +73,7 @@
 (defcustom zeal-at-point-mode-alist
   `((actionscript-mode . "actionscript")
     (arduino-mode . "arduino")
-    (c++-mode . "c++")
+    (c++-mode . "cpp")
     (c-mode . "c")
     (clojure-mode . "clojure")
     (coffee-mode . "coffee")


### PR DESCRIPTION
Fixes issue #32 .