### PR TITLE
Change "python 3" docset tag to "python3"

### DIFF
--- a/zeal-at-point.el
+++ b/zeal-at-point.el
@@ -103,7 +103,7 @@
     (php-mode . "php")
     (processing-mode . "processing")
     (puppet-mode . "puppet")
-    (python-mode . "python 3")
+    (python-mode . "python3")
     (ruby-mode . "ruby")
     (rust-mode . "rust")
     (sass-mode . "sass")


### PR DESCRIPTION
Zeal doesn't recognize "python 3" on my machine, and this fix worked for me.

Using Zeal 0.3.1